### PR TITLE
Fix missing underline style on Safari

### DIFF
--- a/app/src/components/shared/Typer/style.module.scss
+++ b/app/src/components/shared/Typer/style.module.scss
@@ -2,7 +2,7 @@
 
 .typer {
 	--_typer-correct-letter-color: var(--typer-correct-letter-color, var(--correct));
-	--_typer-wrong-letter-color: var(--typer-wrong-letter-color, var(--negative));
+	--_typer-wrong-color: var(--typer-wrong-color, var(--negative));
 	--_typer-extra-letter-color: var(--typer-extra-letter-color, var(--extra));
 	--_typer-untyped-letter-color: var(--typer-untyped-letter-color, var(--untyped));
 	--_typer-cursor-color: var(--typer-cursor-color, var(--cursor-blue));
@@ -43,7 +43,9 @@
 		word-wrap: break-word;
 
 		&--incorrect {
-			text-decoration: var(--_typer-wrong-word-decoration);
+			// Styles must be separated or they get compiled to a format that doesn't work on Safari
+			text-decoration-line: underline;
+			text-decoration-color: var(--_typer-wrong-color);
 		}
 
 		.untyped {

--- a/shared/utils/generateColor.ts
+++ b/shared/utils/generateColor.ts
@@ -1,8 +1,0 @@
-import { CursorColor } from '../types/Cursor'
-import CursorColors from './CursorColors'
-
-export function generateColor(
-	colors: Readonly<CursorColor[]> | CursorColor[] = CursorColors
-): CursorColor {
-	return colors[Math.round(Math.random() * (colors.length - 1))]!
-}


### PR DESCRIPTION
closes #7